### PR TITLE
Copy jenkins-agent logs to /dev/termination-log on cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ spec:
   dnsPolicy: Default
   restartPolicy: Never
   terminationGracePeriodSeconds: 60
-  terminationMessagePolicy: FallbackToLogsOnError
   volumes:
     - name: workspace-volume
       emptyDir: {}

--- a/rootfs/etc/cont-finish.d/cleanup.sh
+++ b/rootfs/etc/cont-finish.d/cleanup.sh
@@ -34,3 +34,12 @@ kind get clusters | xargs --max-lines=1 --no-run-if-empty -- kind delete cluster
 
 echo "Removing all containers..." >&2
 docker ps --all --quiet | xargs --no-run-if-empty -- docker rm --force
+
+# Copy jenkins-agent logs to /dev/termination-log so that K8s can set the
+# termination message.
+if [[ -d "${AGENT_WORKDIR}/remoting/logs" ]]; then
+    echo "Flushing termination log..." >&2
+    find "${AGENT_WORKDIR}/remoting/logs" \
+        -type f -name 'remoting.log.*' -and -not -name 'remoting.log.*.lck' \
+        -exec cat {} ";" | tee /dev/termination-log >/dev/null
+fi


### PR DESCRIPTION
This is a workaround as it does not work in all cases (as mentioned at https://github.com/just-containers/s6-overlay/issues/425#issuecomment-1067124477). Ideally, CMD's stdout and stderr should be redirected to `/dev/termination-log`.
