### PR TITLE
Allow to use as a Jenkinsfile docker agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,10 @@ A full fledged Docker in Docker image to act as a Jenkins Agent. Based on [build
 Spin this agent in shell, if you want to play with it:
 
 ```sh
-# Fetches the latest version
-docker pull ghcr.io/felipecrs/jenkins-agent-dind
-# -ti: allocates a pseudo-TTY in order to run bash
-# --rm: removes the container after using it (don't forget to remove the volumes created by it)
+# -it: allows to interact with the container
+# --rm: removes the container and its volumes after exiting
 # --privileged: needed for running Docker in Docker
-docker run -ti --rm --privileged felipecrs/jenkins-agent-dind bash
+docker run -it --rm --privileged ghcr.io/felipecrs/jenkins-agent-dind bash
 ```
 
 ### Agent Template in Docker Cloud configuration on Jenkins
@@ -64,4 +62,34 @@ spec:
   volumes:
     - name: workspace-volume
       emptyDir: {}
+```
+
+### As a Jenkinsfile docker agent
+
+When running as a Jenkinsfile docker agent, Jenkins will run the container as the host user instead of the default `jenkins` user.
+
+But this image comes with [`fixuid`](https://github.com/boxboat/fixuid), which will automatically fix the user and group IDs of the `jenkins` user that comes with the image to match the host user.
+
+This ensures file permissions are correct when running as a Jenkinsfile docker agent, as well as ensures `docker` from within the container still works.
+
+```groovy
+pipeline {
+  agent {
+    docker {
+      image 'ghcr.io/felipecrs/jenkins-agent-dind:latest'
+      alwaysPull true
+      // --rm: ensures the container volumes are removed after the build
+      // --group-add=docker: is needed when using docker exec to run commands,
+      // which is what Jenkins does when running as a Jenkinsfile docker agent
+      args '--rm --privileged --group-add=docker'
+    }
+  }
+  stages {
+    stage('Verify docker works') {
+      steps {
+        sh 'docker version'
+      }
+    }
+  }
+}
 ```

--- a/init_as_root.sh
+++ b/init_as_root.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+# This script needs to be compiled with shc enabling the suid bit, so we have
+# privileges to operate as root.
+#
+# /init: s6-overlay
+# /s6-setuidgid: drop privileges to the regular user
+exec -- /init s6-setuidgid "${USER?}" "$@"

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This entrypoint first executes fixuid to fix the uid and gid of the user
+# within the to match the user which the container was executed as. Then,
+# executes init_as_root.sh, which operates as root to execute s6-overlay, drops
+# the permissions to the regular user which started the container and executes
+# the passed in CMD.
+
+exec -- fixuid -q -- /init_as_root "$@"


### PR DESCRIPTION
As part of it:

- Add fixuid so that when running with `--user` works as expected
- Add example
- Reduce number of files in home directory so fixuid runs much faster
- Stop installing docker-compose to home user, as it's already installed
  by the docker convenience script
- Several minor improvements
