### PR TITLE
Fix ownership of Jenkins workspace

### DIFF
--- a/rootfs/etc/fix-attrs.d/jenkins-workspace
+++ b/rootfs/etc/fix-attrs.d/jenkins-workspace
@@ -1,0 +1,1 @@
+/home/jenkins/agent false jenkins 0644 0755


### PR DESCRIPTION
Apparently, starting from K8s 1.22, the ownership isn't fixed automatically.