### PR TITLE
Downgrade and pin docker to v23.0.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,16 @@ RUN \
     ${CURL} https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo -E bash -; \
     # nodejs \
     ${CURL} https://deb.nodesource.com/setup_lts.x | sudo -E bash -; \
+    # docker \
+    sudo install -m 0755 -d /etc/apt/keyrings; \
+    ${CURL} https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg; \
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg; \
+    echo \
+        "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        "$(. /etc/os-release && echo "${VERSION_CODENAME}")" stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list; \
     # install apt packages \
+    ${SUDO_APT_GET} update; \
     ${SUDO_APT_GET_INSTALL} \
         git \
         git-lfs \
@@ -167,9 +176,17 @@ RUN \
         traceroute \
         dnsutils \
         netcat \
-        openssh-server; \
-    # install docker \
-    ${CURL} https://get.docker.com | sudo sh; \
+        openssh-server \
+        # docker pre-requisites \
+        ca-certificates \
+        curl \
+        gnupg \
+        # docker \
+        docker-ce \
+        docker-ce-cli \
+        containerd.io \
+        docker-buildx-plugin \
+        docker-compose-plugin; \
     ${SUDO_APT_GET} autoremove -yq; \
     ${SUDO_CLEAN_APT}; \
     # setup docker \

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,8 +182,9 @@ RUN \
         curl \
         gnupg \
         # docker \
-        docker-ce \
-        docker-ce-cli \
+        # Pinning docker to v23 because of https://github.com/docker/buildx/issues/1836 \
+        docker-ce=5:23.0.6-1~ubuntu.20.04~focal \
+        docker-ce-cli=5:23.0.6-1~ubuntu.20.04~focal \
         containerd.io \
         docker-buildx-plugin \
         docker-compose-plugin; \


### PR DESCRIPTION
Because of https://github.com/docker/buildx/issues/1836