### PR TITLE
Downgrade JDK from 11.0.20 to to 11.0.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,7 +153,7 @@ RUN \
         rsync \
         sshpass \
         python3-pip \
-        temurin-11-jdk \
+        temurin-11-jdk=11.0.19.0.0+7 \
         nodejs \
         yarn \
         kubectl \


### PR DESCRIPTION
There is something wrong with this version, causing some projects to fail during compilation. I will try to upgrade again once 11.0.21 gets released.