### PR TITLE
Align remoting version with jenkins/docker-agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,7 @@ ARG APT_GET="apt-get"
 ARG APT_GET_INSTALL="${APT_GET} install -yq --no-install-recommends"
 ARG SUDO_APT_GET="sudo ${APT_GET}"
 ARG SUDO_APT_GET_INSTALL="sudo DEBIANFRONTEND=noninteractive ${APT_GET_INSTALL}"
-ARG CLEAN_APT="rm -rf /var/lib/apt/lists/*"
-ARG SUDO_CLEAN_APT="sudo ${CLEAN_APT}"
+ARG CLEAN_DATA="rm -rf /tmp/* /var/cache/* /usr/share/doc/* /usr/share/man/* /var/lib/apt/lists/*"
 ARG CURL="curl -fsSL"
 ARG NPM_PREFIX="${HOME}/.npm"
 
@@ -86,8 +85,8 @@ RUN group="${NON_ROOT_USER}"; \
     ${APT_GET_INSTALL} \
         sudo \
         locales; \
-    # clean apt cache \
-    ${CLEAN_APT}; \
+    # clean not needed data \
+    ${CLEAN_DATA}; \
     # setup locale \
     sudo sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen; \
     sudo locale-gen; \
@@ -118,6 +117,8 @@ RUN \
     # adoptium openjdk \
     ${CURL} https://packages.adoptium.net/artifactory/api/gpg/key/public | sudo apt-key add -; \
     sudo add-apt-repository --no-update -y "https://packages.adoptium.net/artifactory/deb"; \
+    # jdk installation expects this folder but we deleted during cleanup; \
+    sudo mkdir -p /usr/share/man/man1; \
     # kubernetes \
     ${CURL} https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -; \
     sudo add-apt-repository --no-update -y "deb https://apt.kubernetes.io/ kubernetes-xenial main"; \
@@ -198,7 +199,7 @@ RUN \
         docker-buildx-plugin \
         docker-compose-plugin; \
     ${SUDO_APT_GET} autoremove -yq; \
-    ${SUDO_CLEAN_APT}; \
+    sudo ${CLEAN_DATA}; \
     # setup docker \
     sudo usermod -aG docker "${NON_ROOT_USER}"; \
     ## setup docker-switch (docker-compose v1 compatibility) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -213,7 +213,7 @@ RUN \
     echo 'dockremap:165536:65536' | sudo tee -a /etc/subgid; \
     # install dind hack \
     # https://github.com/moby/moby/commits/master/hack/dind \
-    version="1f32e3c95d72a29b3eaacba156ed675dba976cb5"; \
+    version="d58df1fc6c866447ce2cd129af10e5b507705624"; \
     sudo ${CURL} -o /usr/local/bin/dind "https://raw.githubusercontent.com/moby/moby/${version}/hack/dind"; \
     sudo chmod +x /usr/local/bin/dind; \
     # install jenkins-agent \

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,8 @@ ENV AGENT_WORKDIR="${HOME}/agent" \
     LANG="en_US.UTF-8" \
     LANGUAGE="en_US:en" \
     LC_ALL="en_US.UTF-8" \
+    # from jenkins/docker-agent \
+    TZ="Etc/UTC" \
     ## Entrypoint related \
     # Fails if cont-init and fix-attrs fails \
     S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
@@ -166,6 +168,14 @@ RUN \
         zip \
         unzip \
         time \
+        # from jenkins/docker-agent \
+        openssh-client \
+        patch \
+        tzdata \
+        netbase \
+        less \
+        fontconfig \
+        ca-certificates \
         # required for docker in docker \
         iptables \
         xz-utils \
@@ -207,9 +217,9 @@ RUN \
     sudo ${CURL} -o /usr/local/bin/dind "https://raw.githubusercontent.com/moby/moby/${version}/hack/dind"; \
     sudo chmod +x /usr/local/bin/dind; \
     # install jenkins-agent \
-    base_url="https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting"; \
-    version=$(curl -fsS ${base_url}/maven-metadata.xml | grep "<latest>.*</latest>" | sed -e "s#\(.*\)\(<latest>\)\(.*\)\(</latest>\)\(.*\)#\3#g"); \
-    sudo curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar "${base_url}/${version}/remoting-${version}.jar"; \
+    # the same version as being used in the official agent image \
+    version=$(basename "$(${CURL} -o /dev/null -w "%{url_effective}" https://github.com/jenkinsci/docker-agent/releases/latest)" |  cut -d'-' -f1) ; \
+    sudo curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${version}/remoting-${version}.jar"; \
     sudo chmod 755 /usr/share/jenkins; \
     sudo chmod +x /usr/share/jenkins/agent.jar; \
     sudo ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar; \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A full fledged Docker in Docker image to act as a Jenkins Agent. Based on [build
 
 - Based on **Ubuntu 20.04 Focal Fossa**: a more common OS to run your builds.
 - From `buildpack-deps`: a image with many common dependencies installed, run your builds without hassle.
-- It contains the latest release of `agent.jar`: even more up-to-date than jenkins/agent itself.
 - Fully working Docker in Docker: run your `docker build` commands with no intervention and share of resources between the host.
 - Act just as a Jenkins Agent out-of-the-box: run ephemeral build containers by using Docker Plugin (or Kubernetes Plugin) for Jenkins. Works as the official `jnlp`/`inbound-agent`.
 


### PR DESCRIPTION
So we don't try to use non-tested versions of the remoting library.

Also adds some dependencies from jenkins/docker-agent that were missing
in this image.
