### PR TITLE
Stop publishing to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
 
-    env:
-      DOCKERHUB_USERNAME: felipecrs
-      IMAGE_NAME: jenkins-agent-dind
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,8 +22,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
-            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository_owner }}/jenkins-agent-dind
           tags: |
             type=schedule,pattern=nightly
             type=schedule,pattern={{date 'YYYYMMDD'}}
@@ -38,12 +33,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -59,10 +48,3 @@ jobs:
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-      - if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v4
-        env:
-          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-          DOCKERHUB_REPOSITORY: ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # Jenkins Agent with Docker in Docker
 
 [![CI](https://github.com/felipecrs/jenkins-agent-dind/workflows/ci/badge.svg?branch=master&event=push)](https://github.com/felipecrs/jenkins-agent-dind/actions?query=workflow%3Aci+branch%3Amaster+event%3Apush)
-[![Docker Pulls](https://img.shields.io/docker/pulls/felipecrs/jenkins-agent-dind)](https://hub.docker.com/r/felipecrs/jenkins-agent-dind)
-[![Docker Image Size](https://img.shields.io/docker/image-size/felipecrs/jenkins-agent-dind/latest)](https://hub.docker.com/r/felipecrs/jenkins-agent-dind)
+[![Docker Image Size](https://ghcr-badge.egpl.dev/felipecrs/jenkins-agent-dind/size)](https://github.com/felipecrs/jenkins-agent-dind/pkgs/container/jenkins-agent-dind)
 
-A full fledged Docker in Docker image to act as a Jenkins Agent. Based on `ubuntu`, it is a mashup of [jenkins/inbound-agent](https://github.com/jenkinsci/docker-inbound-agent) with [docker:dind](https://github.com/docker-library/docker).
+A full fledged Docker in Docker image to act as a Jenkins Agent. Based on `ubuntu`, it is a mashup of [`jenkins/inbound-agent`](https://github.com/jenkinsci/docker-inbound-agent) with [`docker:dind`](https://github.com/docker-library/docker).
 
-- Source code: <https://github.com/felipecrs/jenkins-agent-dind>
-- Docker image: <https://hub.docker.com/r/felipecrs/jenkins-agent-dind>
+- Docker image: [`ghcr.io/felipecrs/jenkins-agent-dind`](https://github.com/felipecrs/jenkins-agent-dind/pkgs/container/jenkins-agent-dind)
 
 ## Features
 


### PR DESCRIPTION
I prefer to concentrate on publishing to GitHub Container Registry, so
that I don't need to maintain two accounts and also because this way all
download counts are in one place.

As part of this change, I also removed the Docker image from Docker Hub,
so that when users try to download it again, it will fail and therefore
notice that the image is no longer available there. Otherwise, they
would keep using the old image without noticing that it's no longer
updated.

Unfortunately, there isn't yet a badge for counting ghcr.io pulls: https://github.com/eggplants/ghcr-badge/issues/72.

