### PR TITLE
Remove non-generic packages from image but add pkgx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ ENV NON_ROOT_USER="jenkins"
 ARG NON_ROOT_UID="1000"
 ARG NON_ROOT_HOME="/home/${NON_ROOT_USER}"
 
-ARG NPM_PREFIX="${NON_ROOT_HOME}/.npm"
-ENV PATH="${NPM_PREFIX}/bin:${NON_ROOT_HOME}/.local/bin:${PATH}"
+ENV PATH="${NON_ROOT_HOME}/.local/bin:${PATH}"
 ENV JAVA_HOME="/usr/lib/jvm/temurin-11-jdk-amd64"
 ENV AGENT_WORKDIR="${NON_ROOT_HOME}/agent"
 


### PR DESCRIPTION
I can't include all packages in the world, but pkgx will allow these packages to be easily installed for each use case.

This makes the decompressed image size around 1GB smaller.

If you need Node.js 18 for example:

```console
pkgx install node@18
```
