### PR TITLE
Allow to run as a devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "build": {
+    "context": "..",
+    "dockerfile": "../Dockerfile"
+  },
+  "overrideCommand": false,
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ],
+  "runArgs": ["--network=host"],
+  "postCreateCommand": "pkgx install hadolint k3d helmfile werf kubectl",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "timonwong.shellcheck",
+        "ms-azuretools.vscode-docker",
+        "exiasr.hadolint",
+        "foxundermoon.shell-format",
+        "esbenp.prettier-vscode",
+        "github.vscode-github-actions",
+        "ms-kubernetes-tools.vscode-kubernetes-tools"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,11 +43,7 @@ jobs:
       - name: Setup test dependencies
         uses: pkgxdev/setup@v2
         with:
-          +: >
-            k3d
-            helmfile
-            werf
-            kubectl
+          +: k3d helmfile werf kubectl
 
       - name: Build
         uses: docker/build-push-action@v5

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
     "ms-azuretools.vscode-docker",
     "exiasr.hadolint",
     "foxundermoon.shell-format",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "github.vscode-github-actions",
+    "ms-kubernetes-tools.vscode-kubernetes-tools"
   ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,15 +44,13 @@ ENV LANGUAGE="en_US:en"
 ENV LC_ALL="en_US.UTF-8"
 ENV TZ="Etc/UTC"
 
-ENV CI="true"
-
 RUN --mount=type=bind,source=scripts/prepare_image.sh,target=/prepare_image.sh \
     /prepare_image.sh
 
 COPY --from=rootfs / /
 
 # use non-root user with sudo when needed
-USER "${NON_ROOT_USER}:${NON_ROOT_USER}"
+USER "${NON_ROOT_USER}"
 
 WORKDIR "${AGENT_WORKDIR}"
 
@@ -70,4 +68,4 @@ ENV S6_SERVICES_GRACETIME="15000"
 ENV S6_KEEP_ENV="1"
 
 ENTRYPOINT [ "/entrypoint.sh" ]
-CMD [ "jenkins-agent" ]
+CMD []

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -8,16 +8,30 @@
 
 set -eu
 
+# Handle when no CMD is provided
+if [[ $# -eq 0 ]]; then
+    # If JENKINS_URL is preset, assume we are running as a Kubernetes Pod template agent
+    if [[ -n "${JENKINS_URL:-}" ]]; then
+        set -- jenkins-agent
+    # Otherwise, if attached to a terminal, start a shell
+    elif [[ -t 0 ]]; then
+        set -- bash
+    # Otherwise, just keep the container running
+    else
+        set -- sleep infinity
+    fi
+fi
+
 uid="$(id -u)"
 if [[ "${uid}" -eq 0 ]]; then
     # If running as root, simply execute s6-overlay
     export USER="root"
-    cmd=(/init_as_root)
+    set -- /init_as_root "$@"
 else
     # Otherwise, fix uid and gid, run s6-overlay as root and then drop
     # privileges back to the user
-    export USER="${NON_ROOT_USER}"
-    cmd=(fixdockergid /init_as_root s6-setuidgid "${NON_ROOT_USER}")
+    export USER="${NON_ROOT_USER?}"
+    set -- fixdockergid /init_as_root s6-setuidgid "${NON_ROOT_USER}" "$@"
 fi
 
-exec -- "${cmd[@]}" "$@"
+exec -- "$@"


### PR DESCRIPTION
This changes a bunch of things in the image:

- `CMD` is now empty by default, and we try to assume a good default depending on the situation:
  - If a terminal is attached `-it`, start `bash`
  - If the `JENKINS_URL` environment variable is present, start `jenkins-agent` (retains compatibility with the Kubernetes Plugin)
  - If none of the cases above, `sleep infinity` (good for the devcontainer scenario or when running the image as a service, like a regular pod).
- `CI=true` is no longer set by default. This should be set by Jenkins or by the Jenkinsfile.
- `USER` is now just `jenkins` instead of `jenkins:jenkins` so that all groups of the `jenkins` user are retained when running as a devcontainer.
- Add tip about `--network=host` to README when using the image in Docker on Docker mode.